### PR TITLE
Fix autoload path now that Rails 6 is more strict

### DIFF
--- a/lib/ui_bibz/rails/engine.rb
+++ b/lib/ui_bibz/rails/engine.rb
@@ -18,7 +18,7 @@ module UiBibz
         ActionView::Base.send :include, UiBibz::Helpers::Ui::UxHelper
       end
 
-      config.autoload_paths += Dir["#{config.root}/lib/ui_bibz/inputs/**/"] if defined?(::SimpleForm)
+      config.autoload_paths += Dir["#{config.root}/lib/ui_bibz/inputs/"] if defined?(::SimpleForm)
 
       initializer "ui_bibz.helpers.form" do
         ActionView::Base.send :include, UiBibzForm


### PR DESCRIPTION
Fix autoload paths. The `**/` is problematic because files in `lib/ui_bibz/inputs/*/*.rb` are namespaced. The autoload path must not contain the namespace directories.